### PR TITLE
do not append the db name

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,12 +220,13 @@ spec:
 ```
 
 The referenced secret should have the connection string in it:
-1. `connectionstr`: in the format expected by the golang SQL package. Omit the database.
+1. `connectionstr`: in the format expected by the golang SQL package for your
+particular DB.
 
-For example, to connect to postgres you would specify
-postgres://username:password@ip:port/
+For example, to connect to postgres datbase called myfoodb you would specify
+postgres://username:password@ip:port/myfoodb
 
-postgres://myuser:mysupersecretpassword@127.0.0.1:5432/
+postgres://myuser:mysupersecretpassword@127.0.0.1:5432/myfoodb
 
 This key is made available under `/var/bindings/sql/secrets/`
 
@@ -241,7 +242,7 @@ import (
 )
 
 // Open a connection to the named database.
-db, err := cloudsql.Open(ctx, "postgres", "DATABASENAME")
+db, err := cloudsql.Open(ctx, "postgres")
 ...
 
 ```

--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -19,7 +19,6 @@ package sql
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
@@ -42,23 +41,11 @@ func ReadKey(key string) (string, error) {
 	return string(data), nil
 }
 
-// Open returns a *sql.DB that has been authenticated with the named database.
-func Open(ctx context.Context, dbType, database string) (*sql.DB, error) {
-	// TODO: Add more free form strings here... Like, allow for Username, Password
-	// etc. etc.
-	/*
-		username, err := ReadKey("username")
-		if err != nil {
-			return nil, err
-		}
-		password, err := ReadKey("password")
-		if err != nil {
-			return nil, err
-		}
-	*/
-	connStr, err := ReadKey("connectionstr")
+// Open returns a *sql.DB specified by the connectionstr secret.
+func Open(ctx context.Context, dbType string) (*sql.DB, error) {
+	connstr, err := ReadKey("connectionstr")
 	if err != nil {
 		return nil, err
 	}
-	return sql.Open(dbType, fmt.Sprintf("%s/%s", connStr, database))
+	return sql.Open(dbType, connstr)
 }


### PR DESCRIPTION
Do not require database name, allow the user to configure the entire connection string.