### PR TITLE
serve as webhook

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -141,7 +141,7 @@ func main() {
 		return ctx, nil
 	}
 
-	sharedmain.MainWithContext(ctx, "webhook",
+	sharedmain.WebhookMainWithContext(ctx, "webhook",
 		// Our singleton certificate controller.
 		certificates.NewController,
 


### PR DESCRIPTION
I guess this should be a `WebhookMainWithContext`, in order to listen to the expected port
